### PR TITLE
Add disableRemotes method (opossite as disableExcept)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 var $promise = require('bluebird');
 
 var cls = {};
+var defaultRemotesList = ['create', 'upsert', 'exists', 'updateAll', 'findById', 'find', 'findOne', 'deleteById', 'count', 'prototype.updateAttributes'];
 
 cls.polymorph = function (func) {
   return function () {
@@ -38,10 +39,16 @@ cls.extendDocs = function (model, method, doc) {
   }
 }
 
-cls.disableExcept = function (model, allowList) {
-  var defaultList = ['create', 'upsert', 'exists', 'updateAll', 'findById', 'find', 'findOne', 'deleteById', 'count', 'prototype.updateAttributes'];
+cls.disableRemotes = function (model, disableList) {
+  disableList.forEach(function (remote) {
+    if (defaultRemotesList.indexOf(remote) !== -1) {
+      model.disableRemoteMethod(remote, true);
+    }
+  })
+}
 
-  defaultList.forEach(function (defaultRemote) {
+cls.disableExcept = function (model, allowList) {
+  defaultRemotesList.forEach(function (defaultRemote) {
     if (allowList.indexOf(defaultRemote) === -1) {
       model.disableRemoteMethod(defaultRemote, true);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanopay-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Nanopay tools",
   "keywords": [
     "console",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "should": "^7.0.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/mocha/bin/_mocha test/**/*.js --colors --reporter spec"
   },
   "author": {
     "name": "Alex Struc",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
       "email": "cajoy.dev@gmail.com"
     }
   ],
-  "devDependencies": {},
+  "devDependencies": {
+    "mocha": "^2.2.5",
+    "should": "^7.0.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,41 @@
+var tools = require('../index');
+var should = require('should');
+
+// Test spec
+describe('Nanopay Tools', function () {
+    var fakeModel;
+
+    beforeEach(function () {
+        fakeModel = {
+            disableRemoteMethod: function (method) {
+                this[method] = false;
+            }
+        };
+    });
+
+    it('should disable a list of remote methods', function (done) {
+        tools.disableRemotes(fakeModel, ['find', 'upsert']);
+
+        fakeModel.should.be.ok;
+        fakeModel.find.should.be.false;
+        fakeModel.upsert.should.be.false;
+
+        done();
+    });
+
+    it('should disable all default remote methods except ones on the list', function (done) {
+        fakeModel.find = function () {};
+
+        tools.disableExcept(fakeModel, ['find']);
+
+        fakeModel.should.be.ok;
+
+        fakeModel.create.should.be.false;
+        fakeModel.upsert.should.be.false;
+
+        fakeModel.find.should.be.ok;
+
+        done();
+    });
+
+});


### PR DESCRIPTION
Hello @cajoy.

I wrote this PR because I got into a situation where I would like to just disable a couple methods of a model without iterating through each one and neither pass a big array of methods to disableExcept().

Hope this can be useful somehow.

Cheers,
Will.
